### PR TITLE
Fix rescaling issue in Cheby steps, modify stepsize selection

### DIFF
--- a/include/riccati/chebyshev.hpp
+++ b/include/riccati/chebyshev.hpp
@@ -405,17 +405,17 @@ RICCATI_ALWAYS_INLINE auto spectral_chebyshev(SolverInfo&& info, Scalar x0,
   auto ws = omega(info, x_scaled);
   auto gs = gamma(info, x_scaled);
   auto D2 = eval(info.alloc_,
-                 (4.0 / (h * h) * (D * D) + 4.0 / h * (gs.asDiagonal() * D)));
-  D2 += (ws.array().square()).matrix().asDiagonal();
+                 ((D * D) + h * (gs.asDiagonal() * D)));
+  D2 += ((ws * h / 2.0).array().square()).matrix().asDiagonal();
   const auto n = std::round(std::get<0>(info.chebyshev_[niter]));
   auto D2ic = eval(info.alloc_, matrix_t<complex_t>::Zero(n + 3, n + 1));
   D2ic.topRows(n + 1) = D2;
-  D2ic.row(n + 1) = 2.0 / h * D.row(D.rows() - 1);
+  D2ic.row(n + 1) = D.row(D.rows() - 1);
   auto ic = eval(info.alloc_, vectorc_t::Zero(n + 1));
   ic.coeffRef(n) = complex_t{1.0, 0.0};
   D2ic.row(n + 2) = ic;
   auto rhs = eval(info.alloc_, vectorc_t::Zero(n + 3));
-  rhs.coeffRef(n + 1) = dy0;
+  rhs.coeffRef(n + 1) = dy0 * h / 2.0;
   rhs.coeffRef(n + 2) = y0;
   auto y1 = eval(info.alloc_, D2ic.colPivHouseholderQr().solve(rhs));
   auto dy1 = eval(info.alloc_, 2.0 / h * (D * y1));

--- a/include/riccati/evolve.hpp
+++ b/include/riccati/evolve.hpp
@@ -469,7 +469,7 @@ inline auto evolve(SolverInfo &info, Scalar xi, Scalar xf,
     while (!success) {
       std::tie(success, y, dy, err, y_eval, dy_eval, cheb_N)
           = nonosc_step(info, xcurrent, hslo, yprev, dyprev, eps);
-//      std::cout << "Attempted nonosc step with hslo = " << hslo << ", successful? " << success << std::endl;  
+//      std::cout << "Attempted nonosc step with hslo = " << hslo << ", successful? " << success << std::endl;
       steptype = 0;
       if (!success) {
         hslo *= Scalar{0.5};
@@ -564,7 +564,9 @@ inline auto evolve(SolverInfo &info, Scalar xi, Scalar xf,
     }
     info.alloc_.recover_memory();
   }
+  #ifdef RICCATI_DEBUG
   std::cout << "Total riccati steps: " << successes.size() << std::endl;
+  #endif
   return std::make_tuple(xs, ys, dys, successes, phases, steptypes, yeval,
                          dyeval);
 }

--- a/include/riccati/evolve.hpp
+++ b/include/riccati/evolve.hpp
@@ -438,6 +438,7 @@ inline auto evolve(SolverInfo &info, Scalar xi, Scalar xf,
   std::pair<complex_t, complex_t> a_pair;
   while (std::abs(xcurrent - xf) > Scalar(1e-8)
          && direction * xcurrent < direction * xf) {
+//    std::cout << "t = " << xcurrent << std::endl;
     Scalar phase{0.0};
     bool success = false;
     bool steptype = true;
@@ -445,8 +446,8 @@ inline auto evolve(SolverInfo &info, Scalar xi, Scalar xf,
     int cheb_N = 0;
     arena_matrix<vectorc_t> un(info.alloc_, omega_n.size(), 1);
     arena_matrix<vectorc_t> d_un(info.alloc_, omega_n.size(), 1);
-    if ((direction * hosc > direction * hslo * 5.0)
-        && (direction * hosc * wnext / (2.0 * pi<Scalar>()) > 1.0)) {
+    if (direction * hosc > direction * hslo){
+//        && (direction * hosc * wnext / (2.0 * pi<Scalar>()) > 1.0)) {
       if (hard_stop) {
         if (direction * (xcurrent + hosc) > direction * xf) {
           hosc = xf - xcurrent;
@@ -462,11 +463,13 @@ inline auto evolve(SolverInfo &info, Scalar xi, Scalar xf,
       std::tie(success, y, dy, err, phase, un, d_un, a_pair)
           = osc_step<dense_output>(info, omega_n, gamma_n, xcurrent, hosc,
                                    yprev, dyprev, eps);
+//      std::cout << "Attempted osc step with hosc = " << hosc << ", successful? " << success << std::endl;
       steptype = 1;
     }
     while (!success) {
       std::tie(success, y, dy, err, y_eval, dy_eval, cheb_N)
           = nonosc_step(info, xcurrent, hslo, yprev, dyprev, eps);
+//      std::cout << "Attempted nonosc step with hslo = " << hslo << ", successful? " << success << std::endl;  
       steptype = 0;
       if (!success) {
         hslo *= Scalar{0.5};
@@ -561,6 +564,7 @@ inline auto evolve(SolverInfo &info, Scalar xi, Scalar xf,
     }
     info.alloc_.recover_memory();
   }
+  std::cout << "Total riccati steps: " << successes.size() << std::endl;
   return std::make_tuple(xs, ys, dys, successes, phases, steptypes, yeval,
                          dyeval);
 }


### PR DESCRIPTION
This PR fixes some issues that are not seen when running unit tests, but become clear in integration tests.

1. It scales the linear system to be solved in Chebyshev steps by O(h^2) (where h is the stepsize) to avoid stability issues at small stepsizes

2. It selects the step type slightly differently to allow for earlier switching from Chebyshev to Riccati steps when oscillations are present. This avoids the solver getting stuck performing Chebyshev steps in an oscillatory region.